### PR TITLE
Update for PHP 7.0+ and MediaWiki 1.29+.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.svn
+*~
+*.kate-swp
+.*.swp
+.DS_Store

--- a/ExcludeRandom.i18n.php
+++ b/ExcludeRandom.i18n.php
@@ -1,5 +1,0 @@
-<?php
-$messages = array();
-$messages['en'] = array(
-	'excluderandom-desc' => 'Allows pages to be excluded from [[mw:Help:Random page|Special:Random]]',
-);

--- a/ExcludeRandom.php
+++ b/ExcludeRandom.php
@@ -7,45 +7,20 @@
  *
  * @ingroup Extensions
  * @author Matt Russell
- * @version 0.1
+ * @version 2.0.0
  * @link https://www.mediawiki.org/wiki/Extension:ExcludeRandom Documentation
- * @license BSD
+ * @license BSD-3-Clause
  */
 
-if( !defined( 'MEDIAWIKI' ) ) {
-	die();
-}
-
-// Define extensions info
-$wgExtensionCredits['other'][] = array(
-	'path' => __FILE__,
-	'name' => 'ExcludeRandom',
-	'author' => array( 'Matt Russell', '...' ),
-	'url' => 'https://www.mediawiki.org/wiki/Extension:ExcludeRandom',
-	'descriptionmsg' => 'excluderandom-desc',
-	'version' => 1,
-);
-
-// Define internationalisation file
-$wgExtensionMessagesFiles['ExcludeRandom'] = dirname( __FILE__ ) . '/ExcludeRandom.i18n.php';
-
-$wgHooks['SpecialRandomGetRandomTitle'][] = 'wfExcludeRandomInit';
-function wfExcludeRandomInit( &$rand, &$isRedir, &$namespaces, &$extra, &$title ) {
-	global $wgExcludeRandomPages;
-	if ( !$wgExcludeRandomPages ) {
-		return true;
-	}
-	
-	$db = wfGetDB( DB_SLAVE );
-	foreach ( $wgExcludeRandomPages AS $cond ) {
-		$pattern = $db->strencode( $cond );
-		$pattern = str_replace(
-			array( '_', '%', ' ', '*' ),
-			array( '\_', '\%', '\_', '%' ),
-			$pattern
-		);
-		$extra[] = "`page_title` NOT LIKE '$pattern'";
-	}
-	
-	return true;
+if ( function_exists( 'wfLoadExtension' ) ) {
+	wfLoadExtension( 'ExcludeRandom' );
+	// Keep i18n globals so mergeMessageFileList.php doesn't break
+	$wgMessagesDirs['ExcludeRandom'] = __DIR__ . '/i18n';
+	wfWarn(
+		'Deprecated PHP entry point used for ExcludeRandom extension. Please use wfLoadExtension instead, ' .
+		'see https://www.mediawiki.org/wiki/Extension_registration for more details.'
+	);
+	return;
+} else {
+	die( 'This version of the ExcludeRandom extension requires MediaWiki 1.25+' );
 }

--- a/ExcludeRandomHooks.php
+++ b/ExcludeRandomHooks.php
@@ -1,0 +1,23 @@
+<?php
+class ExcludeRandomHooks {
+	public static function onSpecialRandomGetRandomTitle( &$rand, &$isRedir, &$namespaces, &$extra, &$title ) {
+		$config = \ConfigFactory::getDefaultInstance()->makeConfig('main');
+		$wgExcludeRandomPages = $config->get('ExcludeRandomPages');
+		if ( !is_array( $wgExcludeRandomPages ) || empty( $wgExcludeRandomPages ) ) {
+			return true;
+		}
+
+		$db = wfGetDB( DB_REPLICA );
+		foreach ( $wgExcludeRandomPages as $cond ) {
+			$pattern = $db->strencode( $cond );
+			$pattern = str_replace(
+				[ '_', '%', ' ', '*' ],
+				[ '\_', '\%', '\_', '%' ],
+				$pattern
+			);
+			$extra[] = "`page_title` NOT LIKE '$pattern'";
+		}
+
+		return true;
+	}
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,11 @@
+Copyright 2013 Matt Russell
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/extension.json
+++ b/extension.json
@@ -1,0 +1,31 @@
+{
+	"name": "ExcludeRandom",
+	"version": "2.0.0",
+	"license-name": "BSD-3-Clause",
+	"author": [
+		"Matt Russell"
+	],
+	"url": "https://www.mediawiki.org/wiki/Extension:ExcludeRandom",
+	"descriptionmsg": "excluderandom-desc",
+	"type": "other",
+	"MessagesDirs": {
+		"ExcludeRandomHooks": [
+			"i18n"
+		]
+	},
+	"AutoloadClasses": {
+		"ExcludeRandomHooks": "ExcludeRandomHooks.php"
+	},
+	"Hooks": {
+		"SpecialRandomGetRandomTitle": "ExcludeRandomHooks::onSpecialRandomGetRandomTitle"
+	},
+	"config": {
+		"ExcludeRandomPages": {
+			"value": [],
+			"path": false,
+			"descriptionmsg": "excluderandom-config-excluderandompages",
+			"public": false
+		}
+	},
+	"manifest_version": 2
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,0 +1,6 @@
+{
+	"@metadata": {
+		"authors": ["Matt Russell"]
+	},
+	"excluderandom-desc": "Allows pages to be excluded from [[mw:Help:Random page|Special:Random]]"
+}


### PR DESCRIPTION
This converts to extension registry, i18n JSON files, modern PHP standards, and brings it fully up to date.